### PR TITLE
Remove arg from createWebHashHistory

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -32,7 +32,7 @@ const routes = [
 ]
 
 const router = createRouter({
-    history: createWebHashHistory('/metaverse/'),
+    history: createWebHashHistory(),
     routes,
 });
 


### PR DESCRIPTION
The path from which the root of this application, `'/metaverse/'`, should be specified only once in `vite.config.js`.

For the sake of making this easier for you to review, I did not rebuild. (You shouldn't be pushing `dist` to Github anyways but if you insist,) you should rerun `yarn run build && git add dist && git commit -m 'Rebuild'`